### PR TITLE
Use moment instead of Date library

### DIFF
--- a/app/components/Episode/index.js
+++ b/app/components/Episode/index.js
@@ -5,16 +5,17 @@
 */
 
 import React from 'react';
+import moment from 'moment';
 
 import styles from './styles.css';
 
 function getNormalizedDateString(dateString) {
   const paddedString = (i) => (i < 10 ? `0${i}` : `${i}`);
 
-  const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+  const date = moment(dateString);
+  const year = date.year();
+  const month = date.month() + 1;
+  const day = date.date();
 
   return `${paddedString(day)}.${paddedString(month)}.${year}`;
 }

--- a/app/containers/Post/index.js
+++ b/app/containers/Post/index.js
@@ -33,10 +33,10 @@ export class Post extends React.Component { // eslint-disable-line react/prefer-
   getNormalizedDateString(dateString) {
     const paddedString = i => (i < 10 ? `0${i}` : `${i}`);
 
-    const date = new Date(dateString);
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1;
-    const day = date.getDate();
+    const date = moment(dateString);
+    const year = date.year();
+    const month = date.month() + 1;
+    const day = date.date();
 
     return `${paddedString(day)}.${paddedString(month)}.${year}`;
   }

--- a/app/containers/Show/index.js
+++ b/app/containers/Show/index.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
+import moment from 'moment';
 import {
   selectShow,
   selectShowLoading,
@@ -45,10 +46,10 @@ export class Show extends React.Component { // eslint-disable-line react/prefer-
     }));
 
     const elementList = posts.concat(episodes).sort((a, b) => {
-      const dateA = new Date(a.date);
-      const dateB = new Date(b.date);
-      if (dateA < dateB) return 1;
-      if (dateA > dateB) return -1;
+      const dateA = moment(a.date);
+      const dateB = moment(b.date);
+      if (dateA.isBefore(dateB)) return 1;
+      if (dateB.isBefore(dateA)) return -1;
       return 0;
     });
 

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "invariant": "2.2.1",
     "ip": "1.1.3",
     "lodash": "4.15.0",
-    "moment": "^2.14.1",
+    "moment": "^2.15.1",
     "react": "15.3.0",
     "react-dom": "15.3.0",
     "react-helmet": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "invariant": "2.2.1",
     "ip": "1.1.3",
     "lodash": "4.15.0",
-    "moment": "^2.15.1",
+    "moment": "2.15.1",
     "react": "15.3.0",
     "react-dom": "15.3.0",
     "react-helmet": "3.1.0",


### PR DESCRIPTION
This PR fixes the bug where all dates in Safari on iOS and desktop were showing "NaN.NaN.NaN"